### PR TITLE
Fix binary not found on windows

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -12,7 +12,7 @@ p = __dirname
 while not fs.existsSync(path.join(p, 'package.json'))
   p = path.dirname(p)
 
-phantomBin = path.join(p, 'node_modules/phantomjs/bin/phantomjs')
+phantomBin = require('phantomjs').path
 main = path.join(p, 'phantomjs/main.coffee')
 
 


### PR DESCRIPTION
I've just changed the hard-coded path to `require('phantomjs').path` which is the recommended way [according to the author](https://github.com/Obvious/phantomjs#running-via-node).

This solves an error where phantomjs-wrapper was not usable on Windows. Should be still usable on other platforms. Could you check it with your setup?
